### PR TITLE
Fixed logical issue

### DIFF
--- a/drill/index.js
+++ b/drill/index.js
@@ -20,7 +20,7 @@ register("packetReceived", (packet, event) => {
     if(!drillToggled.toggle) return;
     
     var newDate = Date.now()
-    if (worldLoad - newDate <= 3000) return;
+    if (newDate - worldLoad <= 3000) return;
 
     if (Client.isInGui()) return;
     


### PR DESCRIPTION
Difference between dates was growing negatively causing the main event listener to always return after the date check.